### PR TITLE
Resolve compiler warnings

### DIFF
--- a/include/boost/msm/backmp11/favor_compile_time.hpp
+++ b/include/boost/msm/backmp11/favor_compile_time.hpp
@@ -18,7 +18,6 @@
 #include <deque>
 #include <typeindex>
 #include <unordered_map>
-#include <utility>
 
 #include <boost/mpl/filter_view.hpp>
 #include <boost/mpl/for_each.hpp>
@@ -135,7 +134,7 @@ struct chain_row
         typename std::deque<generic_cell>::const_iterator it = one_state.begin();
         while (it != one_state.end() && (res != HANDLED_TRUE && res != HANDLED_DEFERRED ))
         {
-            auto fnc = reinterpret_cast<real_cell>(reinterpret_cast<void*>(*it));
+            auto fnc = reinterpret_cast<real_cell>(*it);
             HandledEnum handled = (*fnc)(fsm,region,state,evt);
             // reject is considered as erasing an error (HANDLED_FALSE)
             if ((HANDLED_FALSE==handled) && (HANDLED_GUARD_REJECT==res) )
@@ -154,7 +153,7 @@ struct chain_row
 // to a function that makes the SM take its transition on the given
 // Event type.
 template<class Fsm, class Stt>
-struct dispatch_table<Fsm, Stt, favor_compile_time>
+class dispatch_table<Fsm, Stt, favor_compile_time>
 {
     using any_event = favor_compile_time::any_event;
 public:

--- a/include/boost/msm/backmp11/state_machine.hpp
+++ b/include/boost/msm/backmp11/state_machine.hpp
@@ -15,7 +15,6 @@
 #include <exception>
 #include <vector>
 #include <functional>
-#include <numeric>
 #include <utility>
 
 #include <boost/core/no_exceptions_support.hpp>
@@ -1848,7 +1847,7 @@ public:
     }
     // otherwise simple handling, no flag => continue
     template <class Event>
-    bool is_event_handling_blocked_helper(const Event& event, mp11::mp_false)
+    bool is_event_handling_blocked_helper(const Event&, mp11::mp_false)
     {
         // no terminate/interrupt states detected
         return false;
@@ -2838,7 +2837,8 @@ BOOST_PP_REPEAT(BOOST_PP_ADD(BOOST_MSM_VISITOR_ARG_SIZE,1), MSM_VISITOR_ARGS_EXE
      }
 
     // the IBM and VC<8 compilers seem to have problems with the friend declaration of dispatch_table
-#if defined (__IBMCPP__) || (defined(_MSC_VER) && (_MSC_VER < 1400))
+    // also clang seems to have a problem with the defer_transition indirection in preprocess_state
+#if defined (__IBMCPP__) || (defined(_MSC_VER) && (_MSC_VER < 1400) || defined(__clang__ ))
      public:
 #endif
     // no transition for event.
@@ -2869,7 +2869,7 @@ BOOST_PP_REPEAT(BOOST_PP_ADD(BOOST_MSM_VISITOR_ARG_SIZE,1), MSM_VISITOR_ARGS_EXE
     {
         return HANDLED_FALSE;
     }
-#if defined (__IBMCPP__) || (defined(_MSC_VER) && (_MSC_VER < 1400))
+#if defined (__IBMCPP__) || (defined(_MSC_VER) && (_MSC_VER < 1400) || defined(__clang__ ))
      private:
 #endif
     // helper function. In cases where the event is wrapped (target is a direct entry states)

--- a/test/CompositeMachine.cpp
+++ b/test/CompositeMachine.cpp
@@ -44,7 +44,7 @@ namespace
     // front-end: define the FSM structure 
     struct player_ : public msm::front::state_machine_def<player_>
     {
-        BOOST_MSM_TEST_DEFINE_DEPENDENT_TEMPLATES(player_);
+        BOOST_MSM_TEST_DEFINE_DEPENDENT_TEMPLATES(player_)
 
         unsigned int start_playback_counter;
         unsigned int can_close_drawer_counter;
@@ -86,7 +86,7 @@ namespace
 
         struct Playing_ : public msm::front::state_machine_def<Playing_>
         {
-            BOOST_MSM_TEST_DEFINE_DEPENDENT_TEMPLATES(Playing_);
+            BOOST_MSM_TEST_DEFINE_DEPENDENT_TEMPLATES(Playing_)
 
             template <class Event,class FSM>
             void on_entry(Event const&,FSM& ) {++entry_counter;}

--- a/test/Entries.cpp
+++ b/test/Entries.cpp
@@ -40,7 +40,7 @@ namespace
     // front-end: define the FSM structure 
     struct Fsm_ : public msm::front::state_machine_def<Fsm_>
     {
-        BOOST_MSM_TEST_DEFINE_DEPENDENT_TEMPLATES(Fsm_);
+        BOOST_MSM_TEST_DEFINE_DEPENDENT_TEMPLATES(Fsm_)
 
         // The list of FSM states
         struct State1 : public msm::front::state<> 
@@ -63,7 +63,7 @@ namespace
         };
         struct SubFsm2_ : public msm::front::state_machine_def<SubFsm2_>
         {
-            BOOST_MSM_TEST_DEFINE_DEPENDENT_TEMPLATES(SubFsm2_);
+            BOOST_MSM_TEST_DEFINE_DEPENDENT_TEMPLATES(SubFsm2_)
             typedef Back<SubFsm2_, Policy> SubFsm2;
 
             unsigned int entry_action_counter;

--- a/test/History.cpp
+++ b/test/History.cpp
@@ -44,7 +44,7 @@ namespace
     // front-end: define the FSM structure 
     struct player_ : public msm::front::state_machine_def<player_>
     {
-        BOOST_MSM_TEST_DEFINE_DEPENDENT_TEMPLATES(player_);
+        BOOST_MSM_TEST_DEFINE_DEPENDENT_TEMPLATES(player_)
 
         unsigned int start_playback_counter;
         unsigned int can_close_drawer_counter;
@@ -86,7 +86,7 @@ namespace
 
         struct Playing_ : public msm::front::state_machine_def<Playing_>
         {
-            BOOST_MSM_TEST_DEFINE_DEPENDENT_TEMPLATES(Playing_);
+            BOOST_MSM_TEST_DEFINE_DEPENDENT_TEMPLATES(Playing_)
 
             template <class Event,class FSM>
             void on_entry(Event const&,FSM& ) {++entry_counter;}

--- a/test/OrthogonalDeferred.cpp
+++ b/test/OrthogonalDeferred.cpp
@@ -55,7 +55,7 @@ namespace
     // front-end: define the FSM structure 
     struct player_ : public msm::front::state_machine_def<player_>
     {
-        BOOST_MSM_TEST_DEFINE_DEPENDENT_TEMPLATES(player_);
+        BOOST_MSM_TEST_DEFINE_DEPENDENT_TEMPLATES(player_)
 
         unsigned int start_playback_counter;
         unsigned int can_close_drawer_counter;
@@ -109,7 +109,7 @@ namespace
         // by another team in another module. For simplicity I just declare it inside player
         struct Playing_ : public msm::front::state_machine_def<Playing_>
         {
-            BOOST_MSM_TEST_DEFINE_DEPENDENT_TEMPLATES(Playing_);
+            BOOST_MSM_TEST_DEFINE_DEPENDENT_TEMPLATES(Playing_)
 
             // when playing, the CD is loaded and we are in either pause or playing (duh)
             typedef mpl::vector2<PlayingPaused,CDLoaded>        flag_list;

--- a/test/OrthogonalDeferred2.cpp
+++ b/test/OrthogonalDeferred2.cpp
@@ -58,7 +58,7 @@ namespace
     // front-end: define the FSM structure 
     struct player_ : public msm::front::state_machine_def<player_>
     {
-        BOOST_MSM_TEST_DEFINE_DEPENDENT_TEMPLATES(player_);
+        BOOST_MSM_TEST_DEFINE_DEPENDENT_TEMPLATES(player_)
 
         // we want deferred events and no state requires deferred events (only the fsm in the
         // transition table), so the fsm does.
@@ -114,7 +114,7 @@ namespace
         // by another team in another module. For simplicity I just declare it inside player
         struct Playing_ : public msm::front::state_machine_def<Playing_>
         {
-            BOOST_MSM_TEST_DEFINE_DEPENDENT_TEMPLATES(Playing_);
+            BOOST_MSM_TEST_DEFINE_DEPENDENT_TEMPLATES(Playing_)
 
             // when playing, the CD is loaded and we are in either pause or playing (duh)
             typedef mpl::vector2<PlayingPaused,CDLoaded>        flag_list;

--- a/test/OrthogonalDeferred3.cpp
+++ b/test/OrthogonalDeferred3.cpp
@@ -57,7 +57,7 @@ namespace
     // front-end: define the FSM structure 
     struct player_ : public msm::front::state_machine_def<player_>
     {
-        BOOST_MSM_TEST_DEFINE_DEPENDENT_TEMPLATES(player_);
+        BOOST_MSM_TEST_DEFINE_DEPENDENT_TEMPLATES(player_)
 
         // we want deferred events and no state requires deferred events (only the fsm in the
         // transition table), so the fsm does.
@@ -113,7 +113,7 @@ namespace
         // by another team in another module. For simplicity I just declare it inside player
         struct Playing_ : public msm::front::state_machine_def<Playing_>
         {
-            BOOST_MSM_TEST_DEFINE_DEPENDENT_TEMPLATES(Playing_);
+            BOOST_MSM_TEST_DEFINE_DEPENDENT_TEMPLATES(Playing_)
 
             // when playing, the CD is loaded and we are in either pause or playing (duh)
             typedef mpl::vector2<PlayingPaused,CDLoaded>        flag_list;

--- a/test/SerializeWithHistory.cpp
+++ b/test/SerializeWithHistory.cpp
@@ -50,7 +50,7 @@ namespace
     // front-end: define the FSM structure 
     struct player_ : public msm::front::state_machine_def<player_>
     {
-        BOOST_MSM_TEST_DEFINE_DEPENDENT_TEMPLATES(player_);
+        BOOST_MSM_TEST_DEFINE_DEPENDENT_TEMPLATES(player_)
 
         unsigned int start_playback_counter;
         unsigned int can_close_drawer_counter;
@@ -92,7 +92,7 @@ namespace
 
         struct Playing_ : public msm::front::state_machine_def<Playing_>
         {
-            BOOST_MSM_TEST_DEFINE_DEPENDENT_TEMPLATES(Playing_);
+            BOOST_MSM_TEST_DEFINE_DEPENDENT_TEMPLATES(Playing_)
 
             template <class Event,class FSM>
             void on_entry(Event const&,FSM& ) {++entry_counter;}

--- a/test/SetStates.cpp
+++ b/test/SetStates.cpp
@@ -21,7 +21,6 @@
 
 namespace msm = boost::msm;
 namespace mpl = boost::mpl;
-namespace fusion = boost::fusion;
 using namespace msm::front;
 
 namespace
@@ -37,13 +36,13 @@ namespace
     struct State : public boost::msm::front::state<>
     {
         template <class Event, class FSM>
-        void on_entry(Event const& e, FSM& fsm)
+        void on_entry(Event const&, FSM&)
         {
             std::cout << "State - on_entry" << "\n";
         };
 
         template <class Event, class FSM>
-        void on_exit(Event const& e, FSM& fsm)
+        void on_exit(Event const&, FSM&)
         {
             std::cout << "State - on_exit" << "\n";
         }
@@ -52,13 +51,13 @@ namespace
     struct TerminateState : public boost::msm::front::terminate_state<>
     {
         template <class Event, class FSM>
-        void on_entry(Event const& e, FSM& fsm)
+        void on_entry(Event const&, FSM&)
         {
             std::cout << "TerminateState - on_entry" << "\n";
         };
 
         template <class Event, class FSM>
-        void on_exit(Event const& e, FSM& fsm)
+        void on_exit(Event const&, FSM&)
         {
             std::cout << "TerminateState - on_exit" << "\n";
         }
@@ -73,16 +72,16 @@ namespace
     {
     struct SubFsm_ : public msm::front::state_machine_def<SubFsm_>
     {
-        BOOST_MSM_TEST_DEFINE_DEPENDENT_TEMPLATES(SubFsm_);
+        BOOST_MSM_TEST_DEFINE_DEPENDENT_TEMPLATES(SubFsm_)
 
         template <class Event, class FSM>
-        void on_entry(Event const& e, FSM& fsm)
+        void on_entry(Event const&, FSM&)
         {
             std::cout << "SubFsm - on_entry" << "\n";
         };
 
         template <class Event, class FSM>
-        void on_exit(Event const& e, FSM& fsm)
+        void on_exit(Event const&, FSM&)
         {
             std::cout << "SubFsm - on_exit" << "\n";
         }
@@ -104,16 +103,16 @@ namespace
 
     struct Fsm_ : public msm::front::state_machine_def<Fsm_>
     {
-        BOOST_MSM_TEST_DEFINE_DEPENDENT_TEMPLATES(Fsm_);
+        BOOST_MSM_TEST_DEFINE_DEPENDENT_TEMPLATES(Fsm_)
 
         template <class Event, class FSM>
-        void on_entry(Event const& e, FSM& fsm)
+        void on_entry(Event const&, FSM&)
         {
             std::cout << "Fsm - on_entry" << "\n";
         };
 
         template <class Event, class FSM>
-        void on_exit(Event const& e, FSM& fsm)
+        void on_exit(Event const&, FSM&)
         {
             std::cout << "Fsm - on_exit" << "\n";
         }

--- a/test/TestConstructor.cpp
+++ b/test/TestConstructor.cpp
@@ -61,7 +61,7 @@ namespace
     // front-end: define the FSM structure 
     struct player_ : public msm::front::state_machine_def<player_>
     {
-        BOOST_MSM_TEST_DEFINE_DEPENDENT_TEMPLATES(player_);
+        BOOST_MSM_TEST_DEFINE_DEPENDENT_TEMPLATES(player_)
 
         player_(SomeExternalContext& context,int someint)
             :context_(context)
@@ -113,7 +113,7 @@ namespace
 
         struct Playing_ : public msm::front::state_machine_def<Playing_>
         {
-            BOOST_MSM_TEST_DEFINE_DEPENDENT_TEMPLATES(Playing_);
+            BOOST_MSM_TEST_DEFINE_DEPENDENT_TEMPLATES(Playing_)
 
             // when playing, the CD is loaded and we are in either pause or playing (duh)
             template <class Event,class FSM>

--- a/test/TestDeferAndMessageQueue.cpp
+++ b/test/TestDeferAndMessageQueue.cpp
@@ -68,7 +68,7 @@ namespace
         struct unexpected_action
         {
             template <class EVT,class FSM,class SourceState,class TargetState>
-            void operator()(EVT const& ,FSM& fsm,SourceState& ,TargetState& )
+            void operator()(EVT const& ,FSM& ,SourceState& ,TargetState& )
             {
                 std::cout << "unexpected action called" << std::endl;
             }


### PR DESCRIPTION
Resolve compiler warnings in backmp11 and the tests.

Settings: `-Wall -Wpedantic -Wextra`